### PR TITLE
[Feature] 부모 비밀번호 입력, 자녀 프로필 선택 화면 생성 - #28

### DIFF
--- a/Wispy/Appcopy.js
+++ b/Wispy/Appcopy.js
@@ -10,7 +10,9 @@ import Onboarding1Screen from './screens/Onboarding1Screen';
 import ProfileSelection from './screens/ProfileSelection';
 import DiaryScreen from './screens/DiaryScreen';
 import OnboardingScreen from './screens/OnboardingScreen';
-import MagicalScreen from './screens/MagicalScreen';
+import ParentAuthScreen from './screens/ParentAuthScreen';
+import ProfileSelectionScreen from './screens/ProfileSelection';
+import ChildSelectionScreen from './screens/ChildSelectionScreen';
 
 const Stack = createNativeStackNavigator();
 
@@ -23,18 +25,13 @@ export default function Appcopy() {
   return (
     <SafeAreaProvider>
       <NavigationContainer>
-        <Stack.Navigator
-          // DiaryScreen을 테스트하기 위해 시작 화면으로 설정합니다.
-          initialRouteName="DiaryScreen"
-          screenOptions={{
-            headerShown: false,
-          }}
+        <Stack.Navigator 
+          initialRouteName="ProfileSelection"
+          screenOptions={{ headerShown: false }}
         >
-          <Stack.Screen name="MagicalScreen" component={MagicalScreen} />
-          <Stack.Screen name="DiaryScreen" component={DiaryScreen} />
-          <Stack.Screen name="ChatScreen" component={ChatScreen} />
-          <Stack.Screen name="ProfileSelection" component={ProfileSelection} />
-          <Stack.Screen name="OnboardingScreen" component={OnboardingScreen} />
+          <Stack.Screen name="ProfileSelection" component={ProfileSelectionScreen} />
+          <Stack.Screen name="ParentAuth" component={ParentAuthScreen} />
+          <Stack.Screen name="ChildSelection" component={ChildSelectionScreen} />
         </Stack.Navigator>
       </NavigationContainer>
     </SafeAreaProvider>

--- a/Wispy/app.json
+++ b/Wispy/app.json
@@ -34,7 +34,8 @@
       "expo-av",
       "expo-asset",
       "expo-video",
-      "react-native-video"
+      "react-native-video",
+      "expo-secure-store"
     ]
   }
 }

--- a/Wispy/package-lock.json
+++ b/Wispy/package-lock.json
@@ -27,6 +27,7 @@
         "expo-font": "~13.0.4",
         "expo-gl": "~15.0.5",
         "expo-linear-gradient": "~14.0.2",
+        "expo-secure-store": "~14.0.1",
         "expo-status-bar": "~2.0.1",
         "expo-video": "~2.0.6",
         "moment": "2.30.1",
@@ -6382,6 +6383,15 @@
       "license": "MIT",
       "dependencies": {
         "invariant": "^2.2.4"
+      }
+    },
+    "node_modules/expo-secure-store": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-14.0.1.tgz",
+      "integrity": "sha512-QUS+j4+UG4jRQalgnpmTvvrFnMVLqPiUZRzYPnG3+JrZ5kwVW2w6YS3WWerPoR7C6g3y/a2htRxRSylsDs+TaQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-status-bar": {

--- a/Wispy/package.json
+++ b/Wispy/package.json
@@ -44,7 +44,8 @@
     "react-native-screens": "~4.4.0",
     "react-native-video": "6.14.1",
     "react-navigation": "^5.0.0",
-    "three": "^0.166.1"
+    "three": "^0.166.1",
+    "expo-secure-store": "~14.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"

--- a/Wispy/screens/ChildSelectionScreen.js
+++ b/Wispy/screens/ChildSelectionScreen.js
@@ -1,17 +1,10 @@
+// ChildSelectionScreen.js
 import React, { useEffect, useState } from 'react';
-import {
-  View,
-  Text,
-  StyleSheet,
-  Image,
-  Pressable,
-  SafeAreaView,
-} from 'react-native';
+import { View, Text, StyleSheet, Image, Pressable, SafeAreaView } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import Colors from '../constants/colors';
 import Fonts from '../constants/fonts';
-
 import WispyLogo from '../assets/images/logo2.png';
 import HaloImage from '../assets/images/halo.png';
 import PlusIcon from '../assets/images/plus.png';
@@ -32,7 +25,7 @@ const avatarMap = {
   sun: Sun,
 };
 
-export default function ProfileSelectionScreen({ navigation }) {
+export default function ChildProfileSelectionScreen({ navigation }) {
   const [profiles, setProfiles] = useState([]);
 
   useEffect(() => {
@@ -58,11 +51,19 @@ export default function ProfileSelectionScreen({ navigation }) {
     setProfiles(updated);
     AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
   };
+  
+  const handleLogout = () => {
+    navigation.replace('ProfileSelection');
+  };
+
+  const handleGoHome = () => {
+    navigation.navigate('ProfileSelection');
+  };
 
   const renderProfileSlot = (profile, index) => {
     if (profile) {
       return (
-        <View style={styles.profileContainer} key={index}>
+        <View style={styles.profileContainer} key={profile.id}>
           <Image source={HaloImage} style={styles.halo} />
           <Image source={avatarMap[profile.avatar]} style={styles.avatar} />
           <Text style={styles.name}>{profile.name}</Text>
@@ -71,7 +72,7 @@ export default function ProfileSelectionScreen({ navigation }) {
     } else {
       return (
         <Pressable
-          key={index}
+          key={`add-${index}`}
           style={styles.profileContainer}
           onPress={handleAddProfile}
         >
@@ -88,19 +89,18 @@ export default function ProfileSelectionScreen({ navigation }) {
 
   return (
     <SafeAreaView style={styles.safeArea}>
-      <View style={styles.logoContainer}>
-        <Image source={WispyLogo} style={styles.logo} />
-      </View>
+        <Pressable onPress={handleGoHome} style={styles.logoContainer}>
+            <Image source={WispyLogo} style={styles.logo} />
+        </Pressable>
 
       <Text style={styles.title}>
-        Choose your <Text style={styles.guardian}>guardian</Text>{' '}
-        <Text style={styles.angel}>angel</Text> to connect with!
+        Manage Child Profiles
       </Text>
 
       <View style={styles.profileGrid}>{profileViews}</View>
 
-      <Pressable onPress={() => navigation.navigate('ParentAuth')}>
-        <Text style={styles.parentLink}>Are you a parent?</Text>
+      <Pressable onPress={handleLogout}>
+        <Text style={styles.parentLink}>Logout</Text>
       </Pressable>
     </SafeAreaView>
   );
@@ -146,7 +146,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     flexWrap: 'wrap',
     justifyContent: 'center',
-    paddingTop: 30,
+    marginTop: 30,
     paddingHorizontal: 10,
   },
   profileContainer: {

--- a/Wispy/screens/ParentAuthScreen.js
+++ b/Wispy/screens/ParentAuthScreen.js
@@ -1,0 +1,260 @@
+// ParentAuthScreen.js
+import React, { useState, useEffect } from 'react';
+import { View, Text, StyleSheet, SafeAreaView, Pressable, Image } from 'react-native';
+import * as SecureStore from 'expo-secure-store';
+
+import Colors from '../constants/colors';
+import Fonts from '../constants/fonts';
+import WispyLogo from '../assets/images/logo2.png';
+
+const PIN_LENGTH = 6;
+const PARENT_PASSWORD_KEY = 'parent_password';
+
+export default function ParentAuthScreen({ navigation }) {
+  const [stage, setStage] = useState('loading');
+  const [pin, setPin] = useState('');
+  const [firstPin, setFirstPin] = useState('');
+  const [error, setError] = useState('');
+
+  // 저장된 비밀번호가 있는지 확인합니다.
+  useEffect(() => {
+    const checkPassword = async () => {
+      try {
+        const storedPassword = await SecureStore.getItemAsync(PARENT_PASSWORD_KEY);
+        // 저장된 비밀번호가 있으면 'enter', 없으면 'create' 단계로 설정합니다.
+        setStage(storedPassword ? 'enter' : 'create');
+      } catch (e) {
+        // 에러가 발생하면 콘솔에 로그를 남기고, 사용자에게 알립니다.
+        console.error('Failed to access SecureStore', e);
+        setError('Security settings could not be loaded.');
+        setStage('create');
+      }
+    };
+    checkPassword();
+  }, []);
+
+  useEffect(() => {
+    if (pin.length !== PIN_LENGTH) return;
+
+    const handlePinComplete = async () => {
+      switch (stage) {
+        case 'create':
+          setFirstPin(pin);
+          setStage('confirm');
+          setPin('');
+          break;
+        case 'confirm':
+          if (pin === firstPin) {
+            try {
+              // 비밀번호가 일치하면 저장합니다.
+              await SecureStore.setItemAsync(PARENT_PASSWORD_KEY, pin);
+              setStage('enter');
+              setPin('');
+            } catch (e) {
+              console.error('Failed to save password to SecureStore', e);
+              setError('An error occurred. Please try again.');
+            }
+          } else {
+            setError('The passcodes do not match. Please try again.');
+            setStage('create');
+            setFirstPin('');
+            setPin('');
+          }
+          break;
+        case 'enter':
+          try {
+            const storedPassword = await SecureStore.getItemAsync(PARENT_PASSWORD_KEY);
+            if (pin === storedPassword) {
+              // 로그인 성공 시, 부모용 프로필 관리 화면으로 이동합니다.
+              navigation.replace('ChildSelection');
+            } else {
+              setError('Incorrect passcode. Please try again.');
+              setPin('');
+            }
+          } catch (e) {
+            console.error('Failed to verify password from SecureStore', e);
+            setError('An error occurred during verification.');
+            setPin('');
+          }
+          break;
+      }
+    };
+
+    handlePinComplete();
+  }, [pin, stage, firstPin, navigation]);
+
+  const handleKeyPress = (num) => {
+    if (error) setError('');
+    if (pin.length < PIN_LENGTH) {
+      setPin(pin + num);
+    }
+  };
+
+  const handleDelete = () => {
+    setPin(pin.slice(0, -1));
+  };
+
+  const handleResetPassword = () => {
+    SecureStore.deleteItemAsync(PARENT_PASSWORD_KEY).then(() => {
+      alert('Passcode has been reset. Please create a new one.');
+      setStage('create');
+      setPin('');
+      setFirstPin('');
+      setError('');
+    });
+  };
+
+  const getTitle = () => {
+    if (stage === 'create') return 'Create a Parent Passcode';
+    if (stage === 'confirm') return 'Confirm Your Passcode';
+    if (stage === 'enter') return 'Enter Parent Passcode';
+    return 'Loading...';
+  };
+
+  const handleGoHome = () => {
+    navigation.navigate('ProfileSelection');
+  };
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <Pressable onPress={handleGoHome} style={styles.logoContainer}>
+          <Image source={WispyLogo} style={styles.logo} />
+      </Pressable>
+      <View style={styles.topContainer}>
+        <Text style={styles.title}>{getTitle()}</Text>
+        {error ? <Text style={styles.errorText}>{error}</Text> : <Text style={styles.errorPlaceholder} />}
+      </View>
+
+      {/* stage가 'loading'이 아닐 때만 PIN 입력 UI를 보여줍니다. */}
+      {stage !== 'loading' && (
+        <>
+          <View style={styles.pinContainer}>
+            {[...Array(PIN_LENGTH)].map((_, i) => (
+              <View key={i} style={[styles.pinDot, pin.length > i && styles.pinDotFilled]} />
+            ))}
+          </View>
+          <View style={styles.keyboardContainer}>
+            {[[1, 2, 3], [4, 5, 6], [7, 8, 9]].map((row, rowIndex) => (
+              <View key={rowIndex} style={styles.keyboardRow}>
+                {row.map((num) => (
+                  <Pressable key={num} style={styles.key} onPress={() => handleKeyPress(num)}>
+                    <Text style={styles.keyText}>{num}</Text>
+                  </Pressable>
+                ))}
+              </View>
+            ))}
+            <View style={styles.keyboardRow}>
+              <View style={styles.keyPlaceholder} />
+              <Pressable style={styles.key} onPress={() => handleKeyPress(0)}>
+                <Text style={styles.keyText}>0</Text>
+              </Pressable>
+              <Pressable style={styles.key} onPress={handleDelete}>
+                <Text style={styles.keyText}>⌫</Text>
+              </Pressable>
+            </View>
+          </View>
+          <Pressable onPress={handleResetPassword}>
+            <Text style={styles.resetLink}>Forgot Passcode?</Text>
+          </Pressable>
+        </>
+      )}
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: Colors.wispyBlue,
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: 20,
+  },
+  topContainer: {
+    alignItems: 'center',
+    width: '100%',
+    flex: 1, 
+    justifyContent: 'center'
+  },
+  logoContainer: {
+    alignSelf: 'flex-start',
+    marginLeft: 24,
+    marginTop: 8,
+  },
+  logo: {
+    width: 100,
+    height: 40,
+    resizeMode: 'contain',
+  },
+  title: {
+    fontSize: 28,
+    color: Colors.wispyNavy,
+    fontFamily: Fonts.suitExtraBold,
+    fontWeight: 'bold',
+  },
+  errorText: {
+    color: Colors.wispyRed,
+    fontFamily: Fonts.suitRegular,
+    fontSize: 14,
+    marginTop:10,
+  },
+  errorPlaceholder: {
+    marginBottom: 10,
+  },
+  pinContainer: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: 40,
+  },
+  pinDot: {
+    width: 30,
+    height: 30,
+    borderRadius: 20,
+    borderWidth: 2,
+    borderColor: Colors.wispyWhite,
+    margin: 10,
+  },
+  pinDotFilled: {
+    backgroundColor: Colors.wispyWhite,
+  },
+  keyboardContainer: {
+    width: '80%',
+    marginTop: 40,
+  },
+  keyboardRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 20,
+  },
+  key: {
+    width: 70,
+    height: 70,
+    borderRadius: 35,
+    backgroundColor: Colors.wispyWhite,
+    justifyContent: 'center',
+    alignItems: 'center',
+    elevation: 3,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.2,
+    shadowRadius: 1.41,
+  },
+  keyPlaceholder: {
+    width: 70,
+    height: 70,
+  },
+  keyText: {
+    fontSize: 28,
+    fontFamily: Fonts.suitHeavy,
+    color: Colors.wispyNavy,
+  },
+  resetLink: {
+    color: Colors.wispyNavy,
+    textDecorationLine: 'underline',
+    fontFamily: Fonts.suitRegular,
+    fontSize: 16,
+    padding: 10,
+    marginTop: 20,
+  },
+});


### PR DESCRIPTION
## 🚘 What kind of work?

- 부모님 전용 화면 생성: 자녀 프로필 선택 화면과 분리된, 부모님을 위한 독립적인 화면 흐름을 구성했습니다.
- 비밀번호 인증 기능 구현: 부모님이 앱의 관리 기능에 접근하기 위해 6자리 PIN 번호를 설정하고 로그인하는 전체 인증 과정을 구현했습니다.
- 자녀 프로필 관리 화면 연결: 비밀번호 인증 성공 후, 자녀 프로필을 관리할 수 있는 화면으로 이동하는 로직을 구현했습니다.

## ✈️ Changes

- 보안 저장소로 마이그레이션: 비밀번호 저장 방식을 기존의 암호화되지 않는 AsyncStorage에서 iOS의 Keychain과 Android의 SharedPreferences를 사용하는 expo-secure-store로 변경하여 보안을 대폭 강화했습니다.
[Expo SecureStore](https://docs.expo.dev/versions/latest/sdk/securestore/)
- 3단계 인증 절차 적용: 최초 비밀번호 생성 시, '생성 → 확인 → 재입력 후 로그인'의 3단계 절차를 적용하여 사용자가 비밀번호를 확실히 인지하고 오류를 줄일 수 있도록 변경했습니다.
- 네비게이션 로직 추가: 부모님 전용 화면(인증, 프로필 관리)의 상단 로고를 누르면 자녀들이 사용하는 초기 프로필 선택 화면으로 돌아갈 수 있는 기능을 추가하였습니다.

## 🎡 Thoughts

- 사용자의 민감한 정보인 비밀번호를 AsyncStorage가 아닌 암호화된 SecureStore에 저장하여 데이터 보안성을 높였습니다.
- 비밀번호 생성 직후 재입력 절차를 추가함으로써, 사용자가 생성한 비밀번호를 확실히 인지하고 사용할 수 있게 하였습니다. 

## 🚥 Screenshot
### ParentAuthScreen
| Create 단계 오입력 | enter 단계 오입력 | password reset |
| --- | --- | --- |
| ![SmartSelect_20250703_063906_Expo Go.jpg](https://github.com/user-attachments/assets/82693de8-aba8-4bf0-af13-f19c8b1102d7) | ![SmartSelect_20250703_063930_Expo Go.jpg](https://github.com/user-attachments/assets/c09cf522-269b-4276-9e72-dd567b4289c4) | ![SmartSelect_20250703_063853_Expo Go.jpg](https://github.com/user-attachments/assets/6ed84bf7-f114-4d38-8b56-fc44a70a5df5) |

### ChildSelectionScreen
| ChildSelectionScreen |
| --- |
| ![SmartSelect_20250703_065037_Expo Go.jpg](https://github.com/user-attachments/assets/88136a59-69ac-43e9-839e-6d725e6fe2ab) |

## 🚖 To Reviewers

- 현재 숫자 6자리를 비밀번호 양식으로 지정했으나 다른 특수 문자나 영어를 혼합하는 형식으로 변경이 필요하다면 알려주세요.
- 'Forgot Passcode?' 기능은 현재 로컬에 저장된 비밀번호 키를 삭제하고 alert를 띄우는 방식으로만 구현되어 있습니다. 자녀가 이를 삭제하고 진입할 수 있기 때문에 추후 이메일 인증 등 구체적인 고도화가 필요할 것 같습니다.

## 🚔 Related Issues

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->

- Related: #28 
